### PR TITLE
[config] Enable Linux and macOS build jobs in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-linux:
-    if: ${{ false }}
+    if: ${{ true }}
     runs-on: ubuntu-latest
 
     steps:
@@ -35,7 +35,7 @@ jobs:
         if-no-files-found: warn
 
   build-macos:
-    if: ${{ false }}
+    if: ${{ true }}
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
Enable the build jobs for Linux and macOS by changing the condition to true.